### PR TITLE
Update so SEO Lite to fallback to default language

### DIFF
--- a/system/expressionengine/third_party/seo_lite_publisher/ext.seo_lite_publisher.php
+++ b/system/expressionengine/third_party/seo_lite_publisher/ext.seo_lite_publisher.php
@@ -130,10 +130,27 @@ class Seo_lite_publisher_ext {
 
     // the SEO Lite content to display in the SEO Lite tab
     public function seo_lite_tab_content($where, $table_name)
-    {
+    {   
+        $lang_id = ee()->publisher_lib->lang_id;
+        $status = ee()->publisher_lib->status;
+        
+        if (ee()->publisher_setting->show_fallback()) {
+            /** CI_DB_result $q */
+            $q = $this->EE->db->get_where('publisher_seolite_content', array(
+                'entry_id' => $entry_id,
+                'site_id' => $this->EE->config->item('site_id'),
+                'publisher_language_id' => $lang_id,
+                'publisher_status' => $status,
+            ));
+            
+            if (!$q->num_rows()) {
+                $lang_id = ee()->publisher_lib->default_lang_id;
+            }
+        }
+        
         // where arr used w/activerecord
-        $where['publisher_lang_id'] = ee()->publisher_lib->lang_id;
-        $where['publisher_status']  = ee()->publisher_lib->status;
+        $where['publisher_lang_id'] = $lang_id;
+        $where['publisher_status']  = $status;
 
         return array(
             'where' => $where,
@@ -165,10 +182,28 @@ class Seo_lite_publisher_ext {
     }
 
     // called from the frontend
-    public function seo_lite_fetch_data($where, $table_name) {
+    public function seo_lite_fetch_data($where, $table_name)
+    {
+        $lang_id = ee()->publisher_lib->lang_id;
+        $status = ee()->publisher_lib->status;
+        
+        if (ee()->publisher_setting->show_fallback()) {
+            /** CI_DB_result $q */
+            $q = $this->EE->db->get_where('publisher_seolite_content', array(
+                'entry_id' => $entry_id,
+                'site_id' => $this->EE->config->item('site_id'),
+                'publisher_language_id' => $lang_id,
+                'publisher_status' => $status,
+            ));
+            
+            if (!$q->num_rows()) {
+                $lang_id = ee()->publisher_lib->default_lang_id;
+            }
+        }
+        
         // where arr used w/activerecord
-        $where['publisher_lang_id'] = ee()->publisher_lib->lang_id;
-        $where['publisher_status']  = ee()->publisher_lib->status;
+        $where['publisher_lang_id'] = $lang_id;
+        $where['publisher_status']  = $status;
 
         return array(
             'where' => $where,


### PR DESCRIPTION
If Publisher's fallback option is enabled, and translated seo data is not found, fallback to the default language.
This is untested, but should work.